### PR TITLE
hash table: use lookup instead of iteration

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -8121,17 +8121,10 @@ struct work *clone_queued_work_bymidstate(struct cgpu_info *cgpu, char *midstate
  * given que hashtable. Code using this function must be able
  * to handle NULL as a return which implies there is no matching work.
  * The calling function must lock access to the que if it is required. */
-struct work *__find_work_byid(struct work *que, uint32_t id)
+struct work *__find_work_byid(struct work *queue, uint32_t id)
 {
-	struct work *work, *tmp, *ret = NULL;
-
-	HASH_ITER(hh, que, work, tmp) {
-		if (work->id == id) {
-			ret = work;
-			break;
-		}
-	}
-
+	struct work *ret = NULL;
+	HASH_FIND_INT(queue, &id, ret);
 	return ret;
 }
 


### PR DESCRIPTION
When a Bitmain device reports a nonce, it also return a `work_id`. The `cgpu_info` object contains a queue of "in flight" work items, in a uthash hash table. Ultimately, the `__find_work_byid` function is used to locate the work item with the given `id` in this hash table. It does this... by iterating over the hash table, although the ids are used as hash keys!

This PR replaces iteration over the whole hash table by direct access to the right element, using the hash. It reduces CPU use when mining at very low difficulty.